### PR TITLE
origin_check を false に

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -17,6 +17,9 @@ Rails.application.configure do
   # Enable server timing
   config.server_timing = true
 
+  # Add the following line to disable forgery_protection_origin_check
+  config.action_controller.forgery_protection_origin_check = false
+
   # Enable/disable caching. By default caching is disabled.
   # Run rails dev:cache to toggle caching.
   if Rails.root.join("tmp/caching-dev.txt").exist?


### PR DESCRIPTION
作成したアプリからPOSTリクエストを実行した際、`request.base_url`と一致しない問題の対策として
`config.action_controller.forgery_protection_origin_check = false` を追記しました
