### PR TITLE
拡張機能をアップデート

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -41,8 +41,8 @@
     "vscode": {
       "extensions": [
         "GitHub.codespaces",
-        "rebornix.Ruby",        // https://github.com/rubyide/vscode-ruby
-        "castwide.solargraph"   // https://github.com/castwide/vscode-solargraph
+        "Shopify.ruby-lsp",   // https://github.com/Shopify/vscode-ruby-lsp
+        "castwide.solargraph" // https://github.com/castwide/vscode-solargraph
       ],
       "settings": {
         // Use Ctrl+Shift+P->Format to format.

--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@
 ## インストール済みの拡張機能について
 より良い学習体験に繋げるため、本テンプレートには以下の VS Code 拡張機能がデフォルトで入っています。
 
-- [:octocat: rubyide/vscode-ruby](https://github.com/rubyide/vscode-ruby):
+- [:octocat: Shopify/vscode-ruby-lsp](https://github.com/Shopify/vscode-ruby-lsp):
   - Ruby コードのハイライトや折り畳みなどが可能になります
 - [:octocat: castwide/vscode-solargraph](https://github.com/castwide/vscode-solargraph):
   - Ruby コードの定義元が調べられるコードジャンプ機能や、Ruby の型情報を使ったコード補完、公式ドキュメントの表示機能などが使えます（以下は[公式のデモ動画](https://github.com/castwide/vscode-solargraph#readme)です）


### PR DESCRIPTION
拡張機能で、非推奨になった `VSCode Ruby` から、推奨されている `Ruby LSP` に変更しました。

🔽 参考
![スクリーンショット 2023-10-20 13 05 08](https://github.com/yasslab/codespaces-railstutorial/assets/41533420/15301182-ca08-426b-84d2-8f633650aa3b)
