### PR TITLE
IRB::TypeCompletion 機能を追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,4 +34,7 @@
 # Ignore master key for decrypting credentials and more.
 /config/master.key
 
+# Ignore history file used by IRB for interactive Ruby.
+.irb_history
+
 dump.rdb

--- a/.irbrc
+++ b/.irbrc
@@ -1,0 +1,1 @@
+IRB.conf[:COMPLETOR] = :type # default is :regexp

--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ end
 group :development do
   gem "web-console", "4.2.0"
   gem "solargraph",  "0.48.0"
+  gem 'irb',         "1.9.0"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -118,8 +118,9 @@ GEM
       actionpack (>= 6.0.0)
       railties (>= 6.0.0)
     io-console (0.6.0)
-    irb (1.6.4)
-      reline (>= 0.3.0)
+    irb (1.9.0)
+      rdoc
+      reline (>= 0.3.8)
     jaro_winkler (1.5.4)
     jbuilder (2.11.5)
       actionview (>= 5.0.0)
@@ -165,6 +166,8 @@ GEM
     nio4r (2.5.9)
     nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
+    nokogiri (1.14.3-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.14.3-x86_64-linux)
       racc (~> 1.4)
     notiffany (0.1.3)
@@ -176,6 +179,8 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
+    psych (5.1.1.1)
+      stringio
     public_suffix (5.0.1)
     puma (5.6.5)
       nio4r (~> 2.0)
@@ -218,8 +223,10 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
+    rdoc (6.6.0)
+      psych (>= 4.0.0)
     regexp_parser (2.7.0)
-    reline (0.3.3)
+    reline (0.4.0)
       io-console (~> 0.5)
     reverse_markdown (2.1.1)
       nokogiri
@@ -274,9 +281,11 @@ GEM
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
     sqlite3 (1.6.1-arm64-darwin)
+    sqlite3 (1.6.1-x86_64-darwin)
     sqlite3 (1.6.1-x86_64-linux)
     stimulus-rails (1.2.1)
       railties (>= 6.0.0)
+    stringio (3.0.9)
     thor (1.2.1)
     tilt (2.1.0)
     timeout (0.3.2)
@@ -307,6 +316,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  x86_64-darwin-21
   x86_64-linux
 
 DEPENDENCIES
@@ -316,6 +326,7 @@ DEPENDENCIES
   guard (= 2.18.0)
   guard-minitest (= 2.4.6)
   importmap-rails (= 1.1.5)
+  irb (= 1.9.0)
   jbuilder (= 2.11.5)
   minitest (= 5.18.0)
   minitest-reporters (= 1.6.0)


### PR DESCRIPTION
Codespaces テンプレートに IRB の新機能を導入しました。

🔽参考
cf. https://github.com/ruby/irb/tree/v1.9.0#how-to-enable-irbtypecompletion

![スクリーンショット 2023-11-13 18 07 59](https://github.com/yasslab/codespaces-railstutorial/assets/41533420/6fae225c-57df-4c62-80b4-a6d786c280a5)
