### PR TITLE
repl_type_completor gem を 0.1.2 にアップデート

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ group :development do
   gem "web-console",         "4.2.0"
   gem "solargraph",          "0.48.0"
   gem "irb",                 "1.10.0"
-  gem "repl_type_completor", "0.1.0"
+  gem "repl_type_completor", "0.1.2"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    abbrev (0.1.1)
+    abbrev (0.1.2)
     actioncable (7.0.4.3)
       actionpack (= 7.0.4.3)
       activesupport (= 7.0.4.3)
@@ -177,7 +177,7 @@ GEM
     parallel (1.22.1)
     parser (3.2.2.0)
       ast (~> 2.4.1)
-    prism (0.18.0)
+    prism (0.19.0)
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -225,16 +225,16 @@ GEM
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
-    rbs (3.3.2)
+    rbs (3.4.1)
       abbrev
     rdoc (6.6.0)
       psych (>= 4.0.0)
     regexp_parser (2.7.0)
     reline (0.4.0)
       io-console (~> 0.5)
-    repl_type_completor (0.1.0)
-      prism (>= 0.18.0)
-      rbs (>= 2.7.0)
+    repl_type_completor (0.1.2)
+      prism (>= 0.19.0, < 0.20.0)
+      rbs (>= 2.7.0, < 4.0.0)
     reverse_markdown (2.1.1)
       nokogiri
     rexml (3.2.5)
@@ -340,7 +340,7 @@ DEPENDENCIES
   puma (= 5.6.5)
   rails (= 7.0.4.3)
   rails-controller-testing (= 1.0.5)
-  repl_type_completor (= 0.1.0)
+  repl_type_completor (= 0.1.2)
   sassc-rails (= 2.1.2)
   selenium-webdriver (= 4.8.3)
   solargraph (= 0.48.0)


### PR DESCRIPTION
`repl_type_completor` gem を 0.1.0 から 0.1.2 にアップデートしました🛠

GitHub - ruby/repl_type_completor
https://github.com/ruby/repl_type_completor