### PR TITLE
Add `gem install ruby-lsp` command along with `solargraph` gem to `onCreateCommand` option

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -24,7 +24,7 @@
   //},
 
   "waitFor": "onCreateCommand",
-  "onCreateCommand": "gem install solargraph -v '0.50.0' -N",
+  "onCreateCommand": "gem install solargraph -v '0.50.0' -N && gem install ruby-lsp -N",
   //"onCreateCommand": "",
   //# => Solargraph gem not found. Run `gem install solargraph` or update your Gemfile.
   "updateContentCommand": "bundle install",


### PR DESCRIPTION
This would fix the following error when opening up Codespaces that use `ruby-lsp` in Japanese Rails Tutorial.

- Ref: https://github.com/Shopify/ruby-lsp/issues/1745

## Error Log

![image](https://github.com/yasslab/codespaces-railstutorial/assets/155807/b9a94585-e282-4927-b3a1-5cff5408027d)


```
Failed to setup the bundle: Command failed: gem install ruby-lsp
ERROR:  Error installing ruby-lsp:
	ERROR: Failed to build gem native extension.

    current directory: /usr/local/rvm/gems/default/gems/prism-0.19.0/ext/prism
/usr/local/bin/ruby extconf.rb
checking for prism.h in /usr/local/rvm/gems/default/gems/prism-0.19.0/include... *** extconf.rb failed ***
Could not create Makefile due to some reason, probably lack of necessary
libraries and/or headers.  Check the mkmf.log file for more details.  You may
need configuration options.

Provided configuration options:
	--with-opt-dir
	--without-opt-dir
	--with-opt-include
	--without-opt-include=${opt-dir}/include
	--with-opt-lib
	--without-opt-lib=${opt-dir}/lib
	--with-make-prog
	--without-make-prog
	--srcdir=.
	--curdir
	--ruby=/usr/local/bin/$(RUBY_BASE_NAME)
/usr/local/lib/ruby/3.2.0/mkmf.rb:490:in `try_do': The compiler failed to generate an executable file. (RuntimeError)
You have to install development tools first.

	from /usr/local/lib/ruby/3.2.0/mkmf.rb:616:in `block in try_compile'
	from /usr/local/lib/ruby/3.2.0/mkmf.rb:565:in `with_werror'
	from /usr/local/lib/ruby/3.2.0/mkmf.rb:616:in `try_compile'
	from /usr/local/lib/ruby/3.2.0/mkmf.rb:1210:in `block in find_header'
	from /usr/local/lib/ruby/3.2.0/mkmf.rb:989:in `block in checking_for'
	from /usr/local/lib/ruby/3.2.0/mkmf.rb:354:in `block (2 levels) in postpone'
	from /usr/local/lib/ruby/3.2.0/mkmf.rb:324:in `open'
	from /usr/local/lib/ruby/3.2.0/mkmf.rb:354:in `block in postpone'
	from /usr/local/lib/ruby/3.2.0/mkmf.rb:324:in `open'
	from /usr/local/lib/ruby/3.2.0/mkmf.rb:350:in `postpone'
	from /usr/local/lib/ruby/3.2.0/mkmf.rb:988:in `checking_for'
	from /usr/local/lib/ruby/3.2.0/mkmf.rb:1209:in `find_header'
	from extconf.rb:62:in `<main>'

extconf failed, exit code 1

Gem files will remain installed in /usr/local/rvm/gems/default/gems/prism-0.19.0 for inspection.
Results logged to /usr/local/rvm/gems/default/extensions/x86_64-linux/3.2.0/prism-0.19.0/gem_make.out
...
```