### PR TITLE
VersionManager を none に変更

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -78,7 +78,7 @@
         
         // Settings for Ruby LSP
         // https://github.com/Shopify/vscode-ruby-lsp
-        "rubyLsp.rubyVersionManager": "rvm",
+        "rubyLsp.rubyVersionManager": "none",
         "rubyLsp.formatter":          "none",
         "rubyLsp.enabledFeatures": {
           "diagnostics": false,


### PR DESCRIPTION
使用していないため、VersionManagerの設定を none に変更しました🛠

参考
https://marketplace.visualstudio.com/items?itemName=Shopify.ruby-lsp#ruby-version-managers
![スクリーンショット 2024-04-01 18 07 48](https://github.com/yasslab/codespaces-railstutorial/assets/41533420/a79fb0ab-42a1-4abc-9ff3-21df6c124a97)
