### PR TITLE
Update Ruby version: 3.2.4 -> 3.2.5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.4"
+ruby "3.2.5"
 
 gem "rails",           "7.0.4.3"
 gem "sassc-rails",     "2.1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,7 +354,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.4p170
+   ruby 3.2.5p208
 
 BUNDLED WITH
    2.5.6


### PR DESCRIPTION
🎫 cf. #18

Ruby versionを 3.2.4 から 3.2.5 にアップデートしました🛠

## 確認方法

1. `update_ruby_v3.2.5` branch に移動
2. Dev Container の起動
<img width="963" alt="Screenshot 2024-08-12 at 9 46 28" src="https://github.com/user-attachments/assets/28c9ba5f-f3af-4b6e-8354-1b2d567c843b">
