### PR TITLE
Fix Ruby version managers settings

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -77,9 +77,11 @@
         "solargraph.hover":       true,
         
         // Settings for Ruby LSP
-        // https://github.com/Shopify/vscode-ruby-lsp
-        "rubyLsp.rubyVersionManager": "none",
-        "rubyLsp.formatter":          "none",
+        // https://github.com/Shopify/ruby-lsp
+        "rubyLsp.rubyVersionManager": {
+          "identifier": "none"
+        },
+        "rubyLsp.formatter": "none",
         "rubyLsp.enabledFeatures": {
           "diagnostics": false,
           "formatting":  false


### PR DESCRIPTION
Ruby on Rails チュートリアルを利用しています
素晴らしいドキュメントを作成いただきありがとうございます

手順に沿って本リポジトリを利用する過程でRuby LSPが起動しないことに気づき、確認したところ設定の構造に変更があったようでした
なお、個人的には `settings.json` ファイルで当該設定を上書きすることで問題を解消できています
ref: https://github.com/Shopify/ruby-lsp/tree/main/vscode#ruby-version-managers

`Ruby LSP: Start` を実行時に発生するエラー

![image](https://github.com/user-attachments/assets/74374ebe-929d-4d94-9d0b-709e7fe7789a)
