### PR TITLE
Update Ruby version: 3.2.5 -> 3.2.6

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.5"
+ruby "3.2.6"
 
 gem "rails",           "7.0.4.3"
 gem "sassc-rails",     "2.1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,7 +354,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.5p208
+   ruby 3.2.6p234
 
 BUNDLED WITH
    2.5.6


### PR DESCRIPTION
Ruby versionを 3.2.5 から 3.2.6 にアップデートしました🛠

参考: https://github.com/devcontainers/images/blob/main/src/ruby/history/dev.md#contents-1