### PR TITLE
vscode-ruby-lspをruby-lspに更新

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -43,10 +43,10 @@
     "vscode": {
       "extensions": [
         "GitHub.codespaces",
-        "Shopify.ruby-lsp",   // https://github.com/Shopify/vscode-ruby-lsp
+        "Shopify.ruby-lsp",   // https://github.com/Shopify/ruby-lsp
         "castwide.solargraph" // https://github.com/castwide/vscode-solargraph
         //"rebornix.Ruby",    // https://github.com/rubyide/vscode-ruby (Deprecated)
-        
+
       ],
       "settings": {
         // General settings for Codespaces (VS Code)
@@ -65,7 +65,7 @@
         },
         "files.associations":     { "*.erb": "erb"  },
         "emmet.includeLanguages": {   "erb": "html" },
-        
+
         // Settings for Solargraph
         // https://github.com/castwide/solargraph
         "solargraph.useBundler":  false,
@@ -78,7 +78,7 @@
         "solargraph.symbols":     true,
         "solargraph.rename":      true,
         "solargraph.hover":       true,
-        
+
         // Settings for Ruby LSP
         // https://github.com/Shopify/ruby-lsp
         "rubyLsp.rubyVersionManager": {

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -165,6 +165,8 @@ GEM
     net-smtp (0.3.3)
       net-protocol
     nio4r (2.5.9)
+    nokogiri (1.14.3-aarch64-linux)
+      racc (~> 1.4)
     nokogiri (1.14.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.14.3-x86_64-darwin)
@@ -289,6 +291,7 @@ GEM
       actionpack (>= 5.2)
       activesupport (>= 5.2)
       sprockets (>= 3.0.0)
+    sqlite3 (1.6.1-aarch64-linux)
     sqlite3 (1.6.1-arm64-darwin)
     sqlite3 (1.6.1-x86_64-darwin)
     sqlite3 (1.6.1-x86_64-linux)
@@ -324,6 +327,7 @@ GEM
     zeitwerk (2.6.7)
 
 PLATFORMS
+  aarch64-linux
   arm64-darwin-21
   x86_64-darwin-21
   x86_64-linux

--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@
 ## インストール済みの拡張機能について
 より良い学習体験に繋げるため、本テンプレートには以下の VS Code 拡張機能がデフォルトで入っています。
 
-- [:octocat: Shopify/vscode-ruby-lsp](https://github.com/Shopify/vscode-ruby-lsp):
-  - Ruby コードを色分けして表示するハイライト機能や、コード補完機能などが使えます（以下は[公式のデモ動画](https://github.com/Shopify/vscode-ruby-lsp#readme)です）\
+- [:octocat: Shopify/ruby-lsp](https://github.com/Shopify/ruby-lsp):
+  - Ruby コードを色分けして表示するハイライト機能や、コード補完機能などが使えます（以下は[公式のデモ動画](https://github.com/Shopify/ruby-lsp#readme)です）\
   ![Ruby LSP Official DEMO](https://i.gyazo.com/71a5c5114b7836d942a5145ca58eadb9.gif) \
   参考記事: [Ruby LSPのコードナビゲーションで強化された主な機能 - TechRacho](https://techracho.bpsinc.jp/hachi8833/2024_07_29/143652)
 


### PR DESCRIPTION
READMEのリンク先が古いことに気づいたので、devcontainerコンフィグ内のコメントURLと合わせて更新しました。

作業中Gemfile.lockも更新されました。