### PR TITLE
Gemfile に concurrent-ruby を追加してバージョンを固定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,6 +13,7 @@ gem "jbuilder",        "2.11.5"
 gem "puma",            "5.6.8"
 gem "bootsnap",        "1.16.0", require: false
 gem "sqlite3",         "1.6.1"
+gem "concurrent-ruby", "1.3.4"
 
 group :development, :test do
   gem 'reline', '0.5.10'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -86,7 +86,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     coderay (1.1.3)
-    concurrent-ruby (1.2.2)
+    concurrent-ruby (1.3.4)
     crass (1.0.6)
     date (3.3.3)
     debug (1.7.1)
@@ -331,6 +331,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (= 1.16.0)
   capybara (= 3.38.0)
+  concurrent-ruby (= 1.3.4)
   debug (= 1.7.1)
   guard (= 2.18.0)
   guard-minitest (= 2.4.6)


### PR DESCRIPTION
### 背景
`bundle update` などで `concurrent-ruby` のバージョンが `1.3.5` になると、Railsコマンドを実行した際にエラーが出る。

```bash
(main) $ rails c
/usr/local/rvm/gems/default/gems/activesupport-7.0.4.3/lib/active_support/logger_thread_safe_level.rb:12:in `<module:LoggerThreadSafeLevel>': uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)

    Logger::Severity.constants.each do |severity|
          ^^^^^^^^^^
        from /usr/local/rvm/gems/default/gems/activesupport-7.0.4.3/lib/active_support/logger_thread_safe_level.rb:9:in `<module:ActiveSupport>'
```

### やったこと

`Gemfile` に `gem "concurrent-ruby", "1.3.4"` を追加した。