### PR TITLE
Gemfle の solargraphも0.52.0 にアップデート

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ end
 
 group :development do
   gem "web-console",         "4.2.0"
-  gem "solargraph",          "0.51.1"
+  gem "solargraph",          "0.52.0"
   gem "irb",                 "1.10.0"
   gem "repl_type_completor", "0.1.2"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,7 +279,7 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     shellany (0.0.1)
-    solargraph (0.51.1)
+    solargraph (0.52.0)
       backport (~> 1.2)
       benchmark
       bundler (~> 2.0)
@@ -297,6 +297,7 @@ GEM
       thor (~> 1.0)
       tilt (~> 2.0)
       yard (~> 0.9, >= 0.9.24)
+      yard-solargraph (~> 0.1)
     sprockets (4.2.1)
       concurrent-ruby (~> 1.0)
       rack (>= 2.2.4, < 4)
@@ -340,6 +341,8 @@ GEM
     xpath (3.2.0)
       nokogiri (~> 1.8)
     yard (0.9.37)
+    yard-solargraph (0.1.0)
+      yard (~> 0.9)
     zeitwerk (2.7.2)
 
 PLATFORMS
@@ -367,7 +370,7 @@ DEPENDENCIES
   repl_type_completor (= 0.1.2)
   sassc-rails (= 2.1.2)
   selenium-webdriver (= 4.8.3)
-  solargraph (= 0.51.1)
+  solargraph (= 0.52.0)
   sprockets-rails (= 3.4.2)
   sqlite3 (= 1.6.1)
   stimulus-rails (= 1.2.1)


### PR DESCRIPTION
cf: #27

`devcontainer.json` の更新に合わせて、`Gemfle` の solargraphも0.52.0 にアップデートしました🛠️