### PR TITLE
Ruby と Solargraph のアップデート

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -25,7 +25,7 @@
 
   "waitFor": "onCreateCommand",
   //"onCreateCommand": "",
-  "onCreateCommand": "gem install solargraph -v '0.52.0' -N",
+  "onCreateCommand": "gem install solargraph -v '0.53.4' -N",
   //"onCreateCommand": "gem install solargraph -v '0.50.0' -N && gem install ruby-lsp -N",
   //"onCreateCommand": "gem install ruby-lsp -N",
   //# => Solargraph gem not found. Run `gem install solargraph` or update your Gemfile.

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.7"
+ruby "3.2.8"
 
 gem "rails",           "7.0.4.3"
 gem "sassc-rails",     "2.1.2"
@@ -22,7 +22,7 @@ end
 
 group :development do
   gem "web-console",         "4.2.0"
-  gem "solargraph",          "0.52.0"
+  gem "solargraph",          "0.53.4"
   gem "irb",                 "1.10.0"
   gem "repl_type_completor", "0.1.2"
 end
@@ -39,4 +39,4 @@ group :test do
 end
 
 # Windows ではタイムゾーン情報用の tzinfo-data gem を含める必要があります
-#gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]
+# gem "tzinfo-data", platforms: %i[ mingw mswin x64_mingw jruby ]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -93,7 +93,7 @@ GEM
     debug (1.7.1)
       irb (>= 1.5.0)
       reline (>= 0.3.1)
-    diff-lcs (1.6.0)
+    diff-lcs (1.6.1)
     erubi (1.13.1)
     ffi (1.17.1-aarch64-linux-gnu)
     ffi (1.17.1-arm64-darwin)
@@ -184,7 +184,7 @@ GEM
     observer (0.1.2)
     ostruct (0.6.1)
     parallel (1.26.3)
-    parser (3.3.7.2)
+    parser (3.3.7.4)
       ast (~> 2.4.1)
       racc
     prism (0.19.0)
@@ -262,7 +262,7 @@ GEM
       rubocop-ast (>= 1.38.0, < 2.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 2.4.0, < 4.0)
-    rubocop-ast (1.41.0)
+    rubocop-ast (1.42.0)
       parser (>= 3.3.7.2)
     ruby-progressbar (1.13.0)
     rubyzip (2.4.1)
@@ -279,7 +279,7 @@ GEM
       rubyzip (>= 1.2.2, < 3.0)
       websocket (~> 1.0)
     shellany (0.0.1)
-    solargraph (0.52.0)
+    solargraph (0.53.4)
       backport (~> 1.2)
       benchmark
       bundler (~> 2.0)
@@ -291,7 +291,7 @@ GEM
       observer (~> 0.1)
       ostruct (~> 0.6)
       parser (~> 3.0)
-      rbs (~> 3.0)
+      rbs (~> 3.3)
       reverse_markdown (>= 2.0, < 4)
       rubocop (~> 1.38)
       thor (~> 1.0)
@@ -370,7 +370,7 @@ DEPENDENCIES
   repl_type_completor (= 0.1.2)
   sassc-rails (= 2.1.2)
   selenium-webdriver (= 4.8.3)
-  solargraph (= 0.52.0)
+  solargraph (= 0.53.4)
   sprockets-rails (= 3.4.2)
   sqlite3 (= 1.6.1)
   stimulus-rails (= 1.2.1)
@@ -379,7 +379,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.7p253
+   ruby 3.2.8p263
 
 BUNDLED WITH
    2.5.6


### PR DESCRIPTION
以下の更新を行いました🛠️

- `Gemfile` で Ruby 3.2.7 -> 3.2.8, solargraph 0.52.0 -> 0.53.4 に更新
- `bundle install`を実行して `Gemfile.lock` を更新
- `devcontainer.json`で solargraph 0.52.0 -> 0.53.4 に更新