### PR TITLE
Update Ruby version: 3.2.9 -> 3.2.10

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 source "https://rubygems.org"
 git_source(:github) { |repo| "https://github.com/#{repo}.git" }
 
-ruby "3.2.9"
+ruby "3.2.10"
 
 gem "rails",           "7.0.4.3"
 gem "sassc-rails",     "2.1.2"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -381,7 +381,7 @@ DEPENDENCIES
   webdrivers (= 5.2.0)
 
 RUBY VERSION
-   ruby 3.2.9p265
+   ruby 3.2.10p266
 
 BUNDLED WITH
    2.5.6


### PR DESCRIPTION
初めまして！
Ruby、Ruby on Rails を初めて勉強していて、Ruby on Rails チュートリアルからこのリポジトリを知りました。

チュートリアルの「1.2.1開発環境」でGitHub Codespacesを使わず、ローカル環境にこちらのリポジトリをcloneしてDockerコンテナを起動したところ、Rubyのバージョンが違うためエラーがおきました。

そのため、GemfileのRubyのバージョンをアップデートしました。

3.2.9 -> 3.2.10

ローカル環境でDockerコンテナを起動して、ロゴ画像が表示されることは確認しました。

素敵なチュートリアル、チュートリアル用のリポジトリを用意してくださったことに感謝します。これからお世話になります！